### PR TITLE
Remove message queue option from README diagram

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,6 @@ flowchart LR
 
     subgraph SERVER
         API["REST API (FastAPI/Flask)"]
-        QUEUE["Message Queue (opsjon)"]
         FCM[Firebase Cloud Messaging]
     end
 


### PR DESCRIPTION
Removed the message queue option from the diagram.